### PR TITLE
Fix in quadratic solver - minus as input inside string

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -395,7 +395,7 @@
             this.button_tg.Name = "button_tg";
             this.button_tg.Size = new System.Drawing.Size(75, 75);
             this.button_tg.TabIndex = 24;
-            this.button_tg.Text = "tg";
+            this.button_tg.Text = "tan";
             this.button_tg.UseVisualStyleBackColor = false;
             this.button_tg.Click += new System.EventHandler(this.button_tg_Click);
             // 
@@ -409,7 +409,7 @@
             this.button_ctg.Name = "button_ctg";
             this.button_ctg.Size = new System.Drawing.Size(75, 75);
             this.button_ctg.TabIndex = 25;
-            this.button_ctg.Text = "ctg";
+            this.button_ctg.Text = "cot";
             this.button_ctg.UseVisualStyleBackColor = false;
             this.button_ctg.Click += new System.EventHandler(this.button_ctg_Click);
             // 

--- a/Form2.cs
+++ b/Form2.cs
@@ -73,12 +73,12 @@ namespace calculate
                     PlotTitle = "y = cos(x)";
                     break;
                 case "tg":
-                    title = "tg(x)";
-                    PlotTitle = "y = tg(x)";
+                    title = "tan(x)";
+                    PlotTitle = "y = tan(x)";
                     break;
                 case "ctg":
-                    title = "ctg(x)";
-                    PlotTitle = "y = ctg(x)";
+                    title = "cot(x)";
+                    PlotTitle = "y = cot(x)";
                     break;
                 case "quad":
                     text = plot_quadratic(a, b, c);

--- a/Form3.cs
+++ b/Form3.cs
@@ -43,6 +43,10 @@ namespace calculate
             {
                 e.SuppressKeyPress = true;
             }
+            else if (textBox_a.Text.Length > 0 && textBox_a.Text[0] != '-' && e.KeyCode == Keys.OemMinus)
+            {
+                e.SuppressKeyPress = true;
+            }
         }
 
         private void textBox_b_KeyDown(object sender, KeyEventArgs e)
@@ -63,6 +67,10 @@ namespace calculate
             {
                 e.SuppressKeyPress = true;
             }
+            else if (textBox_b.Text.Length > 0 && textBox_b.Text[0] != '-' && e.KeyCode == Keys.OemMinus)
+            {
+                e.SuppressKeyPress = true;
+            }
         }
 
         private void textBox_c_KeyDown(object sender, KeyEventArgs e)
@@ -80,6 +88,10 @@ namespace calculate
                 e.SuppressKeyPress = true;
             }
             else if (textBox_c.Text.Contains('-') && e.KeyCode == Keys.OemMinus)
+            {
+                e.SuppressKeyPress = true;
+            }
+            else if (textBox_c.Text.Length > 0 && textBox_c.Text[0] != '-' && e.KeyCode == Keys.OemMinus)
             {
                 e.SuppressKeyPress = true;
             }


### PR DESCRIPTION
Fixed an issue where '-' could be used as input in text boxes in quadratic equation solver even if it was not the first character. Visual fixes for tan and cot plots